### PR TITLE
[Fix] Partial tile / shape intersection

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -24,6 +24,8 @@ localforage.config({
 function coordsIntersectPolygon (coords, shape) {
   var point = turfPoint(coords);
 
+  console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape));
+
   return isPointInPolygon(point, shape)
 }
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -26,7 +26,7 @@ function coordsIntersectPolygon (coords, shape) {
 
   console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape));
 
-  return isPointInPolygon(point, shape) || isPointInPolygon(shape, point)
+  return isPointInPolygon(point, shape)
 }
 
 /**
@@ -219,8 +219,9 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
-          var tileIntersects = shapesIntersect(tileShape, shape);
+          // const tileIntersects = shapesIntersect(tileShape, shape)
           // const tileIntersects = shapesIntersect(shape, tileShape)
+          var tileIntersects = shapesIntersect(tileShape, shape) || shapesIntersect(shape, tileShape);
 
           // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -190,6 +190,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     var origUrl = this._url;
     var geometries = shapes instanceof Array ? shapes : [shapes];
 
+    console.log('[leaflet.offline] getting tile urls for zoom level', zoom, geometries);
+
     this.setUrl(this._url.replace('{z}', zoom), true);
 
     geometries.forEach(function (shape) {
@@ -494,6 +496,8 @@ var ControlSaveTiles = L.Control.extend(/** @lends ControlSaveTiles */ {
     } else {
       zoomLevels = this.options.zoomLevels || [this._map.getZoom()];
     }
+
+    console.log('[leaflet.offline] saving tiles at zoom levels', zoomLevels);
 
     var bounds = this.options.bounds || this._map.getBounds();
     var shapes = this.options.shapes;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -222,7 +222,7 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           // const tileIntersects = shapesIntersect(tileShape, shape)
           var tileIntersects = shapesIntersect(shape, tileShape);
 
-          L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this$1._map);
+          // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -26,7 +26,7 @@ function coordsIntersectPolygon (coords, shape) {
 
   console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape));
 
-  return isPointInPolygon(point, shape)
+  return isPointInPolygon(point, shape) || isPointInPolygon(shape, point)
 }
 
 /**
@@ -219,8 +219,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
-          // const tileIntersects = shapesIntersect(tileShape, shape)
-          var tileIntersects = shapesIntersect(shape, tileShape);
+          var tileIntersects = shapesIntersect(tileShape, shape);
+          // const tileIntersects = shapesIntersect(shape, tileShape)
 
           // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -219,6 +219,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
           var tileIntersects = shapesIntersect(tileShape, shape);
 
+          L.geoJSON(tileShape, { style: { color: 'red' } }).addTo(this$1._map);
+
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -220,10 +220,10 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
 
-          var tileCoords = tileShape.coordinates;
+          var tileCoords = tileShape.coordinates[0];
 
           if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
-            { tileShape.coordinates.pop(); }
+            { tileShape.coordinates[0].pop(); }
 
           var tileIntersects = shapesIntersect(tileShape, shape);
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -219,7 +219,12 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
-          tileShape.coordinates.pop(); // EXPERIMENT (next detect if last element and 2nd to last element equal the first element)
+
+          var tileCoords = tileShape.coordinates;
+
+          if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
+            { tileShape.coordinates.pop(); }
+
           var tileIntersects = shapesIntersect(tileShape, shape);
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this$1._map);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -218,8 +218,9 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);
             var tile = { key: this$1._getStorageKey(url), url: url };
+            var known = tiles.find(function (t) { return t.key === tile.key; });
 
-            if (!tiles.find(function (t) { return t.key === tile.key; })) {
+            if (!known) {
               tiles.push(tile);
             }
           }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -190,8 +190,6 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     var origUrl = this._url;
     var geometries = shapes instanceof Array ? shapes : [shapes];
 
-    console.log('[leaflet.offline] getting tile urls for zoom level', zoom, geometries);
-
     this.setUrl(this._url.replace('{z}', zoom), true);
 
     geometries.forEach(function (shape) {
@@ -231,8 +229,6 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
     // restore url
     this.setUrl(origUrl, true);
-
-    console.log('[leaflet.offline] returning tiles for zoom level', zoom, tiles.length);
 
     return tiles
   }
@@ -498,8 +494,6 @@ var ControlSaveTiles = L.Control.extend(/** @lends ControlSaveTiles */ {
     } else {
       zoomLevels = this.options.zoomLevels || [this._map.getZoom()];
     }
-
-    console.log('[leaflet.offline] saving tiles at zoom levels', zoomLevels);
 
     var bounds = this.options.bounds || this._map.getBounds();
     var shapes = this.options.shapes;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -232,6 +232,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     // restore url
     this.setUrl(origUrl, true);
 
+    console.log('[leaflet.offline] returning tiles for zoom level', zoom, tiles.length);
+
     return tiles
   }
 });

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -34,15 +34,15 @@ function shapesIntersect (shape1, shape2) {
   if (shape1.type == 'Point') {
     return coordsIntersectPolygon(shape1.coordinates, shape2)
   } else if (shape1.type == 'Polygon' || shape1.type == 'MultiLineString') {
-    return shape1.coordinates.find(function (coord1) {
-      return coord1.find(function (coord2) {
+    return shape1.coordinates.some(function (coord1) {
+      return coord1.some(function (coord2) {
         return coordsIntersectPolygon(coord2, shape2)
       })
     })
   } else if (shape1.type == 'MultiPolygon') {
-    return shape1.coordinates.find(function (coord1) {
-      return coord1.find(function (coord2) {
-        return coord2.find(function (coord3) {
+    return shape1.coordinates.some(function (coord1) {
+      return coord1.some(function (coord2) {
+        return coord2.some(function (coord3) {
           return coordsIntersect(coord3, shape2)
         })
       })
@@ -50,11 +50,11 @@ function shapesIntersect (shape1, shape2) {
   } else if (shape1.type == 'Feature') {
     return shapesIntersect(shape1.geometry, shape2)
   } else if (shape1.type == 'GeometryCollection') {
-    return shape1.geometries.find(function (geometry) {
+    return shape1.geometries.some(function (geometry) {
       return shapesIntersect(geometry, shape2)
     })
   } else if (shape1.type == 'FeatureCollection') {
-    return shape1.features.find(function (feature) {
+    return shape1.features.some(function (feature) {
       return shapesIntersect(feature, shape2)
     })
   }
@@ -219,7 +219,7 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
           var tileIntersects = shapesIntersect(tileShape, shape);
 
-          L.geoJSON(tileShape, { style: { color: 'red' } }).addTo(this$1._map);
+          L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this$1._map);
 
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -219,6 +219,7 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
+          tileShape.coordinates.pop(); // EXPERIMENT (next detect if last element and 2nd to last element equal the first element)
           var tileIntersects = shapesIntersect(tileShape, shape);
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this$1._map);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -195,8 +195,6 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     this.setUrl(this._url.replace('{z}', zoom), true);
 
     geometries.forEach(function (shape) {
-      L.geoJSON(shape, { style: { color: 'yellow' } }).addTo(this$1._map);
-
       var boundCoords = geoBox(shape);
       var boundLatLngs = new L.latLngBounds(L.GeoJSON.coordsToLatLngs([
         [boundCoords[0], boundCoords[1]],
@@ -224,8 +222,6 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
             var tile = { key: this$1._getStorageKey(url), url: url };
 
             if (!tiles.find(function (t) { return t.key === tile.key; })) {
-              L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this$1._map);
-
               tiles.push(tile);
             }
           }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -221,13 +221,13 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);
+            var tile = { key: this$1._getStorageKey(url), url: url };
 
-            L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this$1._map);
+            if (!tiles.find(function (t) { return t.key === tile.key; })) {
+              L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this$1._map);
 
-            tiles.push({
-              key: this$1._getStorageKey(url),
-              url: url,
-            });
+              tiles.push(tile);
+            }
           }
         }
       }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -195,6 +195,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     this.setUrl(this._url.replace('{z}', zoom), true);
 
     geometries.forEach(function (shape) {
+      L.geoJSON(shape, { style: { color: 'yellow' } }).addTo(this$1._map);
+
       var boundCoords = geoBox(shape);
       var boundLatLngs = new L.latLngBounds(L.GeoJSON.coordsToLatLngs([
         [boundCoords[0], boundCoords[1]],

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -222,8 +222,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
           var tileCoords = tileShape.coordinates[0];
 
-          if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
-            { tileShape.coordinates[0].pop(); }
+          // if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
+            tileShape.coordinates[0].pop();
 
           var tileIntersects = shapesIntersect(tileShape, shape);
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -220,6 +220,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);
 
+            L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this$1._map);
+
             tiles.push({
               key: this$1._getStorageKey(url),
               url: url,

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -45,7 +45,7 @@ function shapesIntersect (shape1, shape2) {
     return shape1.coordinates.some(function (coord1) {
       return coord1.some(function (coord2) {
         return coord2.some(function (coord3) {
-          return coordsIntersect(coord3, shape2)
+          return coordsIntersectPolygon(coord3, shape2)
         })
       })
     })
@@ -219,13 +219,8 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
-
-          var tileCoords = tileShape.coordinates[0];
-
-          // if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
-            tileShape.coordinates[0].pop();
-
-          var tileIntersects = shapesIntersect(tileShape, shape);
+          // const tileIntersects = shapesIntersect(tileShape, shape)
+          var tileIntersects = shapesIntersect(shape, tileShape);
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this$1._map);
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -24,8 +24,6 @@ localforage.config({
 function coordsIntersectPolygon (coords, shape) {
   var point = turfPoint(coords);
 
-  console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape));
-
   return isPointInPolygon(point, shape)
 }
 
@@ -219,11 +217,7 @@ var TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (var i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           var tilePoint = new L.Point(i, j);
           var tileShape = tilebelt.tileToGeoJSON([tilePoint.x, tilePoint.y, zoom]);
-          // const tileIntersects = shapesIntersect(tileShape, shape)
-          // const tileIntersects = shapesIntersect(shape, tileShape)
           var tileIntersects = shapesIntersect(tileShape, shape) || shapesIntersect(shape, tileShape);
-
-          // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 
           if (tileIntersects) {
             var url = L.TileLayer.prototype.getTileUrl.call(this$1, tilePoint);

--- a/src/ControlSaveTiles.js
+++ b/src/ControlSaveTiles.js
@@ -200,6 +200,8 @@ const ControlSaveTiles = L.Control.extend(/** @lends ControlSaveTiles */ {
       zoomLevels = this.options.zoomLevels || [this._map.getZoom()]
     }
 
+    console.log('[leaflet.offline] saving tiles at zoom levels', zoomLevels)
+
     const bounds = this.options.bounds || this._map.getBounds()
     const shapes = this.options.shapes
 

--- a/src/ControlSaveTiles.js
+++ b/src/ControlSaveTiles.js
@@ -200,8 +200,6 @@ const ControlSaveTiles = L.Control.extend(/** @lends ControlSaveTiles */ {
       zoomLevels = this.options.zoomLevels || [this._map.getZoom()]
     }
 
-    console.log('[leaflet.offline] saving tiles at zoom levels', zoomLevels)
-
     const bounds = this.options.bounds || this._map.getBounds()
     const shapes = this.options.shapes
 

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -9,7 +9,7 @@ export function coordsIntersectPolygon (coords, shape) {
 
   console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape))
 
-  return isPointInPolygon(point, shape) || isPointInPolygon(shape, point)
+  return isPointInPolygon(point, shape)
 }
 
 /**

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -7,6 +7,8 @@ import isPointInPolygon from '@turf/boolean-point-in-polygon'
 export function coordsIntersectPolygon (coords, shape) {
   const point = turfPoint(coords)
 
+  console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape))
+
   return isPointInPolygon(point, shape)
 }
 

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -7,8 +7,6 @@ import isPointInPolygon from '@turf/boolean-point-in-polygon'
 export function coordsIntersectPolygon (coords, shape) {
   const point = turfPoint(coords)
 
-  console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape))
-
   return isPointInPolygon(point, shape)
 }
 

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -9,7 +9,7 @@ export function coordsIntersectPolygon (coords, shape) {
 
   console.log('[leaflet.offline] ~~~ coords in shape?', coords, shape, isPointInPolygon(point, shape))
 
-  return isPointInPolygon(point, shape)
+  return isPointInPolygon(point, shape) || isPointInPolygon(shape, point)
 }
 
 /**

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -28,7 +28,7 @@ export function shapesIntersect (shape1, shape2) {
     return shape1.coordinates.some(coord1 => {
       return coord1.some(coord2 => {
         return coord2.some(coord3 => {
-          return coordsIntersect(coord3, shape2)
+          return coordsIntersectPolygon(coord3, shape2)
         })
       })
     })

--- a/src/Shapes.js
+++ b/src/Shapes.js
@@ -17,15 +17,15 @@ export function shapesIntersect (shape1, shape2) {
   if (shape1.type == 'Point') {
     return coordsIntersectPolygon(shape1.coordinates, shape2)
   } else if (shape1.type == 'Polygon' || shape1.type == 'MultiLineString') {
-    return shape1.coordinates.find(coord1 => {
-      return coord1.find(coord2 => {
+    return shape1.coordinates.some(coord1 => {
+      return coord1.some(coord2 => {
         return coordsIntersectPolygon(coord2, shape2)
       })
     })
   } else if (shape1.type == 'MultiPolygon') {
-    return shape1.coordinates.find(coord1 => {
-      return coord1.find(coord2 => {
-        return coord2.find(coord3 => {
+    return shape1.coordinates.some(coord1 => {
+      return coord1.some(coord2 => {
+        return coord2.some(coord3 => {
           return coordsIntersect(coord3, shape2)
         })
       })
@@ -33,11 +33,11 @@ export function shapesIntersect (shape1, shape2) {
   } else if (shape1.type == 'Feature') {
     return shapesIntersect(shape1.geometry, shape2)
   } else if (shape1.type == 'GeometryCollection') {
-    return shape1.geometries.find(geometry => {
+    return shape1.geometries.some(geometry => {
       return shapesIntersect(geometry, shape2)
     })
   } else if (shape1.type == 'FeatureCollection') {
-    return shape1.features.find(feature => {
+    return shape1.features.some(feature => {
       return shapesIntersect(feature, shape2)
     })
   }

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -168,6 +168,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     // restore url
     this.setUrl(origUrl, true)
 
+    console.log('[leaflet.offline] returning tiles for zoom level', zoom, tiles.length)
+
     return tiles
   }
 })

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,7 +153,12 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-          tileShape.coordinates.pop() // EXPERIMENT (next detect if last element and 2nd to last element equal the first element)
+
+          const tileCoords = tileShape.coordinates
+
+          if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
+            tileShape.coordinates.pop()
+
           const tileIntersects = shapesIntersect(tileShape, shape)
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -131,6 +131,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     this.setUrl(this._url.replace('{z}', zoom), true)
 
     geometries.forEach(shape => {
+      L.geoJSON(shape, { style: { color: 'yellow' } }).addTo(this._map)
+
       const boundCoords = geoBox(shape)
       const boundLatLngs = new L.latLngBounds(L.GeoJSON.coordsToLatLngs([
         [boundCoords[0], boundCoords[1]],

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -157,13 +157,13 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)
+            const tile = { key: this._getStorageKey(url), url }
 
-            L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this._map)
+            if (!tiles.find(t => t.key === tile.key)) {
+              L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this._map)
 
-            tiles.push({
-              key: this._getStorageKey(url),
-              url,
-            })
+              tiles.push(tile)
+            }
           }
         }
       }

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -154,10 +154,10 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
 
-          const tileCoords = tileShape.coordinates
+          const tileCoords = tileShape.coordinates[0]
 
           if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
-            tileShape.coordinates.pop()
+            tileShape.coordinates[0].pop()
 
           const tileIntersects = shapesIntersect(tileShape, shape)
 

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -131,8 +131,6 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     this.setUrl(this._url.replace('{z}', zoom), true)
 
     geometries.forEach(shape => {
-      L.geoJSON(shape, { style: { color: 'yellow' } }).addTo(this._map)
-
       const boundCoords = geoBox(shape)
       const boundLatLngs = new L.latLngBounds(L.GeoJSON.coordsToLatLngs([
         [boundCoords[0], boundCoords[1]],
@@ -160,8 +158,6 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
             const tile = { key: this._getStorageKey(url), url }
 
             if (!tiles.find(t => t.key === tile.key)) {
-              L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this._map)
-
               tiles.push(tile)
             }
           }

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -154,8 +154,9 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)
             const tile = { key: this._getStorageKey(url), url }
+            const known = tiles.find(t => t.key === tile.key)
 
-            if (!tiles.find(t => t.key === tile.key)) {
+            if (!known) {
               tiles.push(tile)
             }
           }

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -155,7 +155,7 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
           const tileIntersects = shapesIntersect(tileShape, shape)
 
-          L.geoJSON(tileShape, { style: { color: 'red' } }).addTo(this._map)
+          L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -155,6 +155,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
           const tileIntersects = shapesIntersect(tileShape, shape)
 
+          L.geoJSON(tileShape, { style: { color: 'red' } }).addTo(this._map)
+
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)
 

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,11 +153,7 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-          // const tileIntersects = shapesIntersect(tileShape, shape)
-          // const tileIntersects = shapesIntersect(shape, tileShape)
           const tileIntersects = shapesIntersect(tileShape, shape) || shapesIntersect(shape, tileShape)
-
-          // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,7 +153,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-          const tileIntersects = shapesIntersect(tileShape, shape)
+          // const tileIntersects = shapesIntersect(tileShape, shape)
+          const tileIntersects = shapesIntersect(shape, tileShape)
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -126,6 +126,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     const origUrl = this._url
     const geometries = shapes instanceof Array ? shapes : [shapes]
 
+    console.log('[leaflet.offline] getting tile urls for zoom level', zoom, geometries)
+
     this.setUrl(this._url.replace('{z}', zoom), true)
 
     geometries.forEach(shape => {

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -156,6 +156,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)
 
+            L.geoJSON(tileShape, { style: { color: 'teal' } }).addTo(this._map)
+
             tiles.push({
               key: this._getStorageKey(url),
               url,

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,6 +153,7 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
+          tileShape.coordinates.pop() // EXPERIMENT (next detect if last element and 2nd to last element equal the first element)
           const tileIntersects = shapesIntersect(tileShape, shape)
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,8 +153,9 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-          const tileIntersects = shapesIntersect(tileShape, shape)
+          // const tileIntersects = shapesIntersect(tileShape, shape)
           // const tileIntersects = shapesIntersect(shape, tileShape)
+          const tileIntersects = shapesIntersect(tileShape, shape) || shapesIntersect(shape, tileShape)
 
           // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -156,7 +156,7 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
           const tileCoords = tileShape.coordinates[0]
 
-          if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
+          // if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
             tileShape.coordinates[0].pop()
 
           const tileIntersects = shapesIntersect(tileShape, shape)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,8 +153,8 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-          // const tileIntersects = shapesIntersect(tileShape, shape)
-          const tileIntersects = shapesIntersect(shape, tileShape)
+          const tileIntersects = shapesIntersect(tileShape, shape)
+          // const tileIntersects = shapesIntersect(shape, tileShape)
 
           // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -153,12 +153,6 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
         for (let i = tileBounds.min.x; i <= tileBounds.max.x; i += 1) {
           const tilePoint = new L.Point(i, j)
           const tileShape = tileToGeoJSON([tilePoint.x, tilePoint.y, zoom])
-
-          const tileCoords = tileShape.coordinates[0]
-
-          // if (tileCoords.length > 4 && tileCoords[tileCoords.length - 1] === tileCoords[tileCoords.length - 2])
-            tileShape.coordinates[0].pop()
-
           const tileIntersects = shapesIntersect(tileShape, shape)
 
           L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -126,8 +126,6 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
     const origUrl = this._url
     const geometries = shapes instanceof Array ? shapes : [shapes]
 
-    console.log('[leaflet.offline] getting tile urls for zoom level', zoom, geometries)
-
     this.setUrl(this._url.replace('{z}', zoom), true)
 
     geometries.forEach(shape => {
@@ -167,8 +165,6 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
 
     // restore url
     this.setUrl(origUrl, true)
-
-    console.log('[leaflet.offline] returning tiles for zoom level', zoom, tiles.length)
 
     return tiles
   }

--- a/src/TileLayerOffline.js
+++ b/src/TileLayerOffline.js
@@ -156,7 +156,7 @@ const TileLayerOffline = L.TileLayer.extend(/** @lends  TileLayerOffline */ {
           // const tileIntersects = shapesIntersect(tileShape, shape)
           const tileIntersects = shapesIntersect(shape, tileShape)
 
-          L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
+          // L.geoJSON(tileShape, { style: { color: 'pink' } }).addTo(this._map)
 
           if (tileIntersects) {
             const url = L.TileLayer.prototype.getTileUrl.call(this, tilePoint)


### PR DESCRIPTION
**Problem**

Some of the tile intersections (particularly those at more distant zoom levels) were not being detected properly, resulting in only partial downloads for certain layers.

**Solution**

It turns out that argument order matters to `@turf/boolean-point-in-polygon`. That's all I really know so far.

It's not the cleanest solution, but we overcome this by simply checking the intersections with both parameter orderings (i.e. `(a,b)` and `(b,a)`).

I also added a (hopefully temporary) check for duplicate tile matches. This started happening with the other fix, and I'm not sure why either, but we'll just have to live with it for now given our timeline.

**Notes**

I suggest squashing this merge, I had to push to a remote branch for any of my changes to work properly because of idiosyncrasies of NPM :/